### PR TITLE
Fix field descriptions in overlap studies and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ wheels/
 # Virtual environments
 .venv
 .vscode/
+.gemini/

--- a/src/ta_lib_mcp_server/tools/overlap_studies.py
+++ b/src/ta_lib_mcp_server/tools/overlap_studies.py
@@ -71,7 +71,9 @@ def register_overlap_studies(mcp):
         annotations=common_tool_annotations,
     )
     def calculate_ema(
-        real: Annotated[list[float], Field(description="")],
+        real: Annotated[
+            list[float], Field(description="Array of real values for calculation")
+        ],
         timeperiod: Annotated[
             int, Field(description="Number of periods for EMA calculation")
         ] = 30,
@@ -251,7 +253,9 @@ def register_overlap_studies(mcp):
             float,
             Field(description="Acceleration factor for SAR calculation (step size)"),
         ] = 0,
-        maximum: Annotated[float, Field(description="")] = 0,
+        maximum: Annotated[
+            float, Field(description="Maximum value for the acceleration factor")
+        ] = 0,
     ):
         high_nparray = np.array(high, dtype=np.float64)
         low_nparray = np.array(low, dtype=np.float64)
@@ -268,14 +272,28 @@ def register_overlap_studies(mcp):
     def calculate_sarext(
         high: Annotated[list[float], Field(description="Array of high prices")],
         low: Annotated[list[float], Field(description="Array of low prices")],
-        startvalue: Annotated[float, Field(description="")] = 0,
-        offsetonreverse: Annotated[float, Field(description="")] = 0,
-        accelerationinitlong: Annotated[float, Field(description="")] = 0,
-        accelerationlong: Annotated[float, Field(description="")] = 0,
-        accelerationmaxlong: Annotated[float, Field(description="")] = 0,
-        accelerationinitshort: Annotated[float, Field(description="")] = 0,
-        accelerationshort: Annotated[float, Field(description="")] = 0,
-        accelerationmaxshort: Annotated[float, Field(description="")] = 0,
+        startvalue: Annotated[float, Field(description="Start value for SAR")] = 0,
+        offsetonreverse: Annotated[
+            float, Field(description="Offset to apply on reversal")
+        ] = 0,
+        accelerationinitlong: Annotated[
+            float, Field(description="Initial acceleration factor for long positions")
+        ] = 0,
+        accelerationlong: Annotated[
+            float, Field(description="Acceleration factor for long positions")
+        ] = 0,
+        accelerationmaxlong: Annotated[
+            float, Field(description="Maximum acceleration factor for long positions")
+        ] = 0,
+        accelerationinitshort: Annotated[
+            float, Field(description="Initial acceleration factor for short positions")
+        ] = 0,
+        accelerationshort: Annotated[
+            float, Field(description="Acceleration factor for short positions")
+        ] = 0,
+        accelerationmaxshort: Annotated[
+            float, Field(description="Maximum acceleration factor for short positions")
+        ] = 0,
     ):
         high_nparray = np.array(high, dtype=np.float64)
         low_nparray = np.array(low, dtype=np.float64)


### PR DESCRIPTION
This PR improves the field descriptions in the overlap studies module and updates the gitignore file.

## Changes Made:
- **EMA function**: Added proper description for the \`real\` parameter
- **SAR function**: Added proper description for the \`maximum\` parameter  
- **SAREXT function**: Added comprehensive descriptions for all parameters:
  - \`startvalue\`: Start value for SAR
  - \`offsetonreverse\`: Offset to apply on reversal
  - \`accelerationinitlong\`: Initial acceleration factor for long positions
  - \`accelerationlong\`: Acceleration factor for long positions
  - \`accelerationmaxlong\`: Maximum acceleration factor for long positions
  - \`accelerationinitshort\`: Initial acceleration factor for short positions
  - \`accelerationshort\`: Acceleration factor for short positions
  - \`accelerationmaxshort\`: Maximum acceleration factor for short positions
- **Gitignore**: Added \`.gemini/\` to exclude AI assistant files

## Impact:
- Improves API documentation and user experience
- Makes the MCP server tools more self-documenting
- Prevents accidental commits of AI assistant files

These changes enhance the usability of the TA-Lib MCP server by providing clear, descriptive field documentation for users.